### PR TITLE
Add missing items prefix to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,27 +42,27 @@ items.runtime | Integer | Runtime length of the property. In seconds. | |
 items.contributions Object[] | An array of contributors. You may supply anything but director and cast are most useful for matching titles | | 
 items.contributions.role | String | Type of contribution. We look for either _creator_, _cast_, or _dirctor_. Other roles may be supplied as well. | | 
 items.contributions.name | String | Name of the contributor. 
-artwork | Object[] | An array of Key art. URLs to the images are expected. | | 
-artwork.type | String| Type of art. Values expected are _thumbnail_, _poster_, or _scene | |
-artwork.url | String| URL to the image. | | 
-language_formats | Object[] | Array of languages and their formats.  | | 
-language_formats.type | String | Kind of format either _audio_ or _subtitles_  | | 
-language_formats.label | String | Description presented to the consumer.  | | 
-language_formats.format | String | Relevant encoding format. | | 
-language_formats.code | String | International code for language. ie. _en_ for English. | | 
-available_formats | Object[] | Array of availabilities | |
-available_formats.delivery_method | String | Specifies method of consumer delivery. We expect either _stream_, _download_, _theatrical, _mail_, or _physical_ | |
-available_formats.format | String | Quality of content. Usually _sd_ or _hd_ but provider may specify their own properietary formats. 
-available_formats.product_id | String | Partners propietary SKU or ID number | | 
-available_formats.product_url | String | URL to direct point of purchase. 
-available_formats.availabilities | Object[] | Array of specific availabilies. Mainly rent, buy, or purchase. | |
-available_formats.availabilities.offer | String | Kind of offer. We expect either _rent_, _buy_, or _subscription_ | |
-available_formats.availabilities.start | String | Date of when content is available for purchase to consumer. | | 
-available_formats.availabilities.end | String | Date of when content expires. 
-available_formats.availabilities.subscription_required | Boolean| Specifies if subscription is required to view content. | |
-available_formats.availabilities.price | Object[] | List of prices in respective currencies.
-available_formats.availabilities.price.currency | String | Name of currency. ie. "USD" |  |
-available_formats.availabilities.price.price | String | Numerical value of price in respective currency. | | 
+items.artwork | Object[] | An array of Key art. URLs to the images are expected. | | 
+items.artwork.type | String| Type of art. Values expected are _thumbnail_, _poster_, or _scene | |
+items.artwork.url | String| URL to the image. | | 
+items.language_formats | Object[] | Array of languages and their formats.  | | 
+items.language_formats.type | String | Kind of format either _audio_ or _subtitles_  | | 
+items.language_formats.label | String | Description presented to the consumer.  | | 
+items.language_formats.format | String | Relevant encoding format. | | 
+items.language_formats.code | String | International code for language. ie. _en_ for English. | | 
+items.available_formats | Object[] | Array of availabilities | |
+items.available_formats.delivery_method | String | Specifies method of consumer delivery. We expect either _stream_, _download_, _theatrical, _mail_, or _physical_ | |
+items.available_formats.format | String | Quality of content. Usually _sd_ or _hd_ but provider may specify their own properietary formats. 
+items.available_formats.product_id | String | Partners propietary SKU or ID number | | 
+items.available_formats.product_url | String | URL to direct point of purchase. 
+items.available_formats.availabilities | Object[] | Array of specific availabilies. Mainly rent, buy, or purchase. | |
+items.available_formats.availabilities.offer | String | Kind of offer. We expect either _rent_, _buy_, or _subscription_ | |
+items.available_formats.availabilities.start | String | Date of when content is available for purchase to consumer. | | 
+items.available_formats.availabilities.end | String | Date of when content expires. 
+items.available_formats.availabilities.subscription_required | Boolean| Specifies if subscription is required to view content. | |
+items.available_formats.availabilities.price | Object[] | List of prices in respective currencies.
+items.available_formats.availabilities.price.currency | String | Name of currency. ie. "USD" |  |
+items.available_formats.availabilities.price.price | String | Numerical value of price in respective currency. | | 
 ----
 
 


### PR DESCRIPTION
Adds items prefix to:
- Artwork.
- Language Formats.
- Available Formats.

Inferred from example JSON.
